### PR TITLE
Miscellaneous cleanups and test improvments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 DJANGO ?= "Django>=1.8,<1.9"
+CELERY ?= "celery>=3.0,<4.0"
 
 testenv:
 	pip install -e .
 	pip install --upgrade pip wheel
-	pip install celery coverage $(DJANGO) flake8 mock 
+	pip install $(DJANGO) $(CELERY) coverage flake8 mock
 
 flake8:
 	flake8 post_request_task

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ django-post-request-task
 .. image:: https://travis-ci.org/mozilla/django-post-request-task.svg?branch=master
     :target: https://travis-ci.org/mozilla/django-post-request-task
 
-A celery task class whose execution is delayed until after the request
+A celery 3.x task class whose execution is delayed until after the request
 finishes, using `request_started` and `request_finished` signals from django
 and thread locals.
 
@@ -48,6 +48,9 @@ Or, if you are using the task decorator directly:
 
 That's it. If the task is called from outside the django request-response
 cycle, then it will be triggered normally.
+
+As a bonus feature, if the same task is called with the same argument several
+times during a request-response cycle, it will only be queued up once.
 
 
 Running tests

--- a/post_request_task/tests.py
+++ b/post_request_task/tests.py
@@ -1,4 +1,5 @@
-from django.core.signals import request_finished, request_started
+from django.core.signals import (got_request_exception, request_finished,
+                                 request_started)
 from django.test import TestCase
 
 from celery import current_app
@@ -18,6 +19,11 @@ def test_task():
     task_mock()
 
 
+@task
+def test_task_with_args_and_kwargs(foo, bar=None):
+    task_mock(foo, bar=bar)
+
+
 class TestTask(TestCase):
 
     def setUp(self):
@@ -31,56 +37,92 @@ class TestTask(TestCase):
         _stop_queuing_tasks()
         super(TestTask, self).tearDown()
 
-    def _verify_task_filled(self):
+    def _verify_one_task_queued(self):
+        self._verify_x_tasks_queued(1, ((),), ({},))
+
+    def _verify_x_tasks_queued(
+            self, expected_size, expected_args, expected_kwargs,
+            expected_extra_kw=None, test_task=test_task):
         queue = _get_task_queue()
         size = len(queue)
-        self.assertEqual(size,  1,
-                         'Expected 1 task in the queue, found %d' % size)
-        cls, args, kwargs = queue[0]
         self.assertEqual(
-            cls.name,
-            '%s.%s' % (test_task.__module__, test_task.__name__),
-            'Expected the test task, found %s' % cls.name)
+            size, expected_size,
+            'Expected %d task in the queue, found %d.' % (expected_size, size))
+        for i, item in enumerate(queue):
+            cls, args, kwargs, extrakw = item
+            self.assertEqual(
+                cls.name,
+                '%s.%s' % (test_task.__module__, test_task.__name__),
+                'Expected the test task, found %s.' % cls.name)
+            self.assertEqual(
+                args,
+                expected_args[i],
+                'Expected args %s, found %s.' % (expected_args[i], args))
+            self.assertEqual(
+                kwargs,
+                expected_kwargs[i],
+                'Expected kwargs %s, found %s.' % (expected_kwargs[i], kwargs))
+            if expected_extra_kw:
+                self.assertEqual(
+                    extrakw,
+                    expected_extra_kw[i],
+                    'Expected extra kwargs %s, found %s.' % (
+                        expected_extra_kw[i], extrakw))
 
     def _verify_task_empty(self):
         assert len(_get_task_queue()) == 0, (
             'Expected empty queue, got %s: %s' % (len(_get_task_queue()),
                                                   _get_task_queue()))
 
-    def test_task(self):
+    def test_task_should_be_called_immediately(self):
         test_task.delay()
-        assert task_mock.called
+        self.assertEqual(task_mock.call_count, 1)
 
-    def test_task_in_request(self):
+    def test_task_with_args_and_kwargs(self):
+        test_task_with_args_and_kwargs.delay(42, bar='rista')
+        self.assertEqual(task_mock.call_count, 1)
+        self.assertEqual(task_mock.call_args[0], (42,))
+        self.assertEqual(task_mock.call_args[1], {'bar': 'rista'})
+
+    def test_task_in_request_should_not_be_called_immediately(self):
         request_started.send(sender=self)
         test_task.delay()
-        assert not task_mock.called
+        self.assertEqual(task_mock.call_count, 0)
+
+    def test_task_in_request_with_args_and_kwargs(self):
+        request_started.send(sender=self)
+        test_task.delay(42, foo='bar')
+        self.assertEqual(task_mock.call_count, 0)
 
     @patch('post_request_task.task.PostRequestTask.original_apply_async')
-    def test_request_finished(self, _mock):
+    def test_task_applied_once_request_finished(
+            self, original_apply_async_mock):
         request_started.send(sender=self)
         test_task.delay()
-        self._verify_task_filled()
+        self._verify_one_task_queued()
 
         request_finished.send(sender=self)
         self._verify_task_empty()
 
         # Assert the original `apply_async` called.
-        assert _mock.called, (
+        self.assertEqual(
+            original_apply_async_mock.call_count, 1,
             'Expected PostRequestTask.original_apply_async call')
 
     @patch('post_request_task.task.PostRequestTask.original_apply_async')
-    def test_request_failed(self, _mock):
+    def test_task_discarded_when_request_failed(
+            self, original_apply_async_mock):
         request_started.send(sender=self)
         test_task.delay()
-        self._verify_task_filled()
+        self._verify_one_task_queued()
 
         # Simulate a request exception.
-        _discard_tasks()
+        got_request_exception.send(sender=self)
         self._verify_task_empty()
 
         # Assert the original `apply_async` was not called.
-        assert not _mock.called, (
+        self.assertEqual(
+            original_apply_async_mock.call_count, 0,
             'Unexpected PostRequestTask.original_apply_async call')
 
     def test_deduplication(self):
@@ -89,4 +131,55 @@ class TestTask(TestCase):
         test_task.delay()
         test_task.delay()
 
-        self._verify_task_filled()
+        self._verify_one_task_queued()
+
+    def test_tasks_deduplication_with_different_arguments(self):
+        """Test arguments sent to the task are used when de-duping."""
+        request_started.send(sender=self)
+        test_task_with_args_and_kwargs.delay(42)
+        test_task_with_args_and_kwargs.delay(42, bar='rista')
+        test_task_with_args_and_kwargs.delay(42, bar='rista')
+
+        self._verify_x_tasks_queued(
+            2,  # 2 tasks should have been kept.
+            ((42,), (42,)),  # Each of those tasks sent "42" as the only arg...
+            ({}, {'bar': 'rista'}),  # ... Only the second one sent kwargs.
+            test_task=test_task_with_args_and_kwargs)
+
+    def test_tasks_deduplication_with_different_keyword_arguments(self):
+        """Test keyword arguments sent to the task are used when de-duping."""
+        request_started.send(sender=self)
+        test_task_with_args_and_kwargs.delay(42, bar='rista')
+        test_task_with_args_and_kwargs.delay(42, bar='rista')
+        test_task_with_args_and_kwargs.delay(42, bar='atheon')
+        test_task_with_args_and_kwargs.delay(42, bar='rage')
+        test_task_with_args_and_kwargs.delay(42, bar='rista')
+        test_task_with_args_and_kwargs.delay(42, bar='rage')
+
+        self._verify_x_tasks_queued(
+            3,
+            ((42,), (42,), (42, )),
+            ({'bar': 'rista'}, {'bar': 'atheon'}, {'bar': 'rage'}),
+            test_task=test_task_with_args_and_kwargs)
+
+    def test_tasks_deduplication_with_celery_keywords(self):
+        """Test celery-specific keyword arguments are used when de-duping."""
+        request_started.send(sender=self)
+        # Note that we are using apply_async() instead of delay() to allow us
+        # to pass celery-specific arguments, as a result we have to send the
+        # positional arguments with args=() and the keyword arguments with
+        # kwargs={}. Everything else is an argument to the apply_async() call
+        # itself.
+        test_task_with_args_and_kwargs.apply_async(
+            args=(42,), kwargs={'bar': 'rista'}, retry=3)
+        test_task_with_args_and_kwargs.apply_async(
+            args=(42,), kwargs={'bar': 'rista'}, retry=1)
+        test_task_with_args_and_kwargs.apply_async(
+            args=(42,), kwargs={'bar': 'rista'}, retry=3)
+
+        self._verify_x_tasks_queued(
+            2,
+            ((42, ), (42, )),
+            ({'bar': 'rista'}, {'bar': 'rista'}),
+            ({'retry': 3}, {'retry': 1}),
+            test_task=test_task_with_args_and_kwargs)

--- a/runtests.py
+++ b/runtests.py
@@ -18,6 +18,11 @@ django.setup()
 
 from django.test.runner import DiscoverRunner
 
-failures = DiscoverRunner(verbosity=1).run_tests(['post_request_task'])
+if len(sys.argv) > 1:
+    target = sys.argv[1:]
+else:
+    target = ['post_request_task']
+
+failures = DiscoverRunner(verbosity=1).run_tests(target)
 if failures:
     sys.exit(failures)


### PR DESCRIPTION
Not the best commit message, I know.

This adds things that @kumar303 requested in mozilla/olympia/pull/1495. While doing that I found a minor bug in the way arguments were passed, because of the weird signature [celery's `apply_async()`](http://celery.readthedocs.org/en/latest/reference/celery.app.task.html#celery.app.task.Task.apply_async) has. It didn't seem to have much consequences in our code, but tests revealed the issue so I changed it.