### PR TITLE
Add test support for django 1.6 and 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,12 @@ env:
   - DJANGO_VERSION=1.10.x
   - DJANGO_VERSION=1.9.x
   - DJANGO_VERSION=1.8.x
+  - DJANGO_VERSION=1.7.x
+  - DJANGO_VERSION=1.6.x
 
 
 install:
   - pip install tox
 
 script:
-  - tox -e "$TRAVIS_PYTHON_VERSION-$DJANGO_VERSION"
+  - ./travis_test_runner.sh

--- a/runtests.py
+++ b/runtests.py
@@ -13,8 +13,10 @@ settings.configure(
     },
     INSTALLED_APPS=()
 )
-django.setup()
 
+# Only django versions from 1.7 on have setup
+if hasattr(django, 'setup'):
+    django.setup()
 
 from django.test.runner import DiscoverRunner
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,10 @@ commands =
     pip install --use-wheel -e .[tests]
     make test
 
+deps16 =
+    https://github.com/django/django/archive/stable/1.6.x.tar.gz#egg=django
+deps17 =
+    https://github.com/django/django/archive/stable/1.7.x.tar.gz#egg=django
 deps18 =
     https://github.com/django/django/archive/stable/1.8.x.tar.gz#egg=django
 deps19 =
@@ -17,6 +21,16 @@ deps19 =
 deps110 =
     https://github.com/django/django/archive/stable/1.10.x.tar.gz#egg=django
 
+
+[testenv:2.7-1.6.x]
+basepython = python2.7
+deps =
+    {[testenv]deps16}
+
+[testenv:2.7-1.7.x]
+basepython = python2.7
+deps =
+    {[testenv]deps17}
 
 [testenv:2.7-1.8.x]
 basepython = python2.7
@@ -32,6 +46,16 @@ deps =
 basepython = python2.7
 deps =
     {[testenv]deps110}
+
+[testenv:3.4-1.6.x]
+basepython = python3.4
+deps =
+    {[testenv]deps16}
+
+[testenv:3.4-1.7.x]
+basepython = python3.4
+deps =
+    {[testenv]deps17}
 
 [testenv:3.4-1.8.x]
 basepython = python3.4
@@ -62,6 +86,16 @@ deps =
 basepython = python3.5
 deps =
     {[testenv]deps110}
+
+[testenv:pypy-1.6.x]
+basepython = pypy
+deps =
+    {[testenv]deps16}
+
+[testenv:pypy-1.7.x]
+basepython = pypy
+deps =
+    {[testenv]deps17}
 
 [testenv:pypy-1.8.x]
 basepython = pypy

--- a/travis_test_runner.sh
+++ b/travis_test_runner.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then
+  if [[ "$DJANGO_VERSION" == "1.6.x" || "$DJANGO_VERSION" == "1.7.x" ]]; then
+    echo "$DJANGO_VERSION is not compatible with $TRAVIS_PYTHON_VERSION so skipping the test"
+    exit 0
+  fi
+fi
+
+tox -e "$TRAVIS_PYTHON_VERSION-$DJANGO_VERSION"


### PR DESCRIPTION
Hello, I'm not sure if this pull request would be accepted or if there is more I should do with it to be accepted. I thought with only django 1.9 supporting the `on_commit` signal that older versions of django can still benefit from this library. Thank you.

Commit message:

While no longer officially supported django versions, this library does
run fine against it and is supported in setup.py.

The only "gotcha" is that 1.6 and 1.7 are not compatible with python 3.5
so those tests are skipped during the travis tests.