### PR TITLE
Feature update python, django and celery versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - '2.7'
   - '3.4'
   - '3.5'
+  - '3.6'
   - pypy
 
 cache:
@@ -13,10 +14,17 @@ cache:
         - $HOME/.cache/pip
 
 env:
+  - DJANGO_VERSION=1.11.x
   - DJANGO_VERSION=1.10.x
-  - DJANGO_VERSION=1.9.x
   - DJANGO_VERSION=1.8.x
 
+
+matrix:
+  exclude:
+    - python: '3.6'
+      env: DJANGO_VERSION=1.8.x
+    - python: '3.6'
+      env: DJANGO_VERSION=1.10.x
 
 install:
   - pip install tox

--- a/post_request_task/tests.py
+++ b/post_request_task/tests.py
@@ -51,10 +51,10 @@ class TestTask(TestCase):
             'Expected %d task in the queue, found %d.' % (expected_size, size))
         for i, item in enumerate(queue):
             cls, args, kwargs, extrakw = item
-            self.assertEqual(
-                cls.name,
-                '%s.%s' % (test_task.__module__, test_task.__name__),
-                'Expected the test task, found %s.' % cls.name)
+            self.assertTrue(
+                isinstance(cls, test_task.__class__),
+                'Expected the test_task, found %s.' % cls.name
+            )
             self.assertEqual(
                 args,
                 expected_args[i],

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ def read(*parts):
 
 
 install_requires = [
-    'Django>=1.6,<1.11',
-    'celery>=3.0,<4.0',
+    'Django>=1.6,<1.12',
+    'celery>=3.0,<5.0',
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,10 +12,10 @@ commands =
 
 deps18 =
     https://github.com/django/django/archive/stable/1.8.x.tar.gz#egg=django
-deps19 =
-    https://github.com/django/django/archive/stable/1.9.x.tar.gz#egg=django
 deps110 =
     https://github.com/django/django/archive/stable/1.10.x.tar.gz#egg=django
+deps111 =
+    https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
 
 
 [testenv:2.7-1.8.x]
@@ -23,57 +23,62 @@ basepython = python2.7
 deps =
     {[testenv]deps18}
 
-[testenv:2.7-1.9.x]
-basepython = python2.7
-deps =
-    {[testenv]deps19}
-
-[testenv:2.7-1.10.x]
-basepython = python2.7
-deps =
-    {[testenv]deps110}
-
 [testenv:3.4-1.8.x]
 basepython = python3.4
 deps =
     {[testenv]deps18}
-
-[testenv:3.4-1.9.x]
-basepython = python3.4
-deps =
-    {[testenv]deps19}
-
-[testenv:3.4-1.10.x]
-basepython = python3.4
-deps =
-    {[testenv]deps110}
 
 [testenv:3.5-1.8.x]
 basepython = python3.5
 deps =
     {[testenv]deps18}
 
-[testenv:3.5-1.9.x]
-basepython = python3.5
+[testenv:2.7-1.10.x]
+basepython = python2.7
 deps =
-    {[testenv]deps19}
+    {[testenv]deps110}
+
+[testenv:3.4-1.10.x]
+basepython = python3.4
+deps =
+    {[testenv]deps110}
 
 [testenv:3.5-1.10.x]
 basepython = python3.5
 deps =
     {[testenv]deps110}
 
+[testenv:2.7-1.11.x]
+basepython = python2.7
+deps =
+    {[testenv]deps111}
+
+[testenv:3.4-1.11.x]
+basepython = python3.4
+deps =
+    {[testenv]deps111}
+
+[testenv:3.5-1.11.x]
+basepython = python3.5
+deps =
+    {[testenv]deps111}
+
+[testenv:3.6-1.11.x]
+basepython = python3.6
+deps =
+    {[testenv]deps111}
+
 [testenv:pypy-1.8.x]
 basepython = pypy
 deps =
     {[testenv]deps18}
 
-[testenv:pypy-1.9.x]
-basepython = pypy
-deps =
-    {[testenv]deps19}
-
 [testenv:pypy-1.10.x]
 basepython = pypy
 deps =
     {[testenv]deps110}
+
+[testenv:pypy-1.11.x]
+basepython = pypy
+deps =
+    {[testenv]deps111}


### PR DESCRIPTION
This PR is long time updated, but this feature can be useful for many users  (https://github.com/mozilla/django-post-request-task/pull/8).

Add python3.6 version, add Django-1.11 and cleaned other django-python supports according to https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django, removed django-1.9 according to https://www.djangoproject.com/download/#supported-versions.