### PR TITLE
Move to xenial on TravisCI, Drop Python 3.4, 3.5 and add Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - 2.7
   - 3.6
   - 3.7
-  - pypy
 
 cache: pip
 
@@ -22,8 +21,6 @@ matrix:
     - python: pypy
       env: DJANGO_VERSION=2.0.x
     - python: 2.7
-      env: DJANGO_VERSION=2.1.x
-    - python: pypy
       env: DJANGO_VERSION=2.1.x
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ env:
 
 matrix:
   exclude:
-    - python: '2.7'
+    - python: 2.7
       env: DJANGO_VERSION=2.0.x
-    - python: 'pypy'
+    - python: pypy
       env: DJANGO_VERSION=2.0.x
-    - python: '2.7'
+    - python: 2.7
       env: DJANGO_VERSION=2.1.x
-    - python: 'pypy'
+    - python: pypy
       env: DJANGO_VERSION=2.1.x
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache: pip
 env:
   - DJANGO_VERSION=2.0.x
   - DJANGO_VERSION=2.1.x
+  - DJANGO_VERSION=2.2.x
   - DJANGO_VERSION=1.11.x
 
 matrix:
@@ -20,6 +21,8 @@ matrix:
       env: DJANGO_VERSION=2.0.x
     - python: 2.7
       env: DJANGO_VERSION=2.1.x
+    - python: 2.7
+      env: DJANGO_VERSION=2.2.x
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ matrix:
   exclude:
     - python: 2.7
       env: DJANGO_VERSION=2.0.x
-    - python: pypy
-      env: DJANGO_VERSION=2.0.x
     - python: 2.7
       env: DJANGO_VERSION=2.1.x
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,30 @@
-sudo: false
+dist: xenial
 
 language: python
 
 python:
-  - '2.7'
-  - '3.4'
-  - '3.5'
-  - '3.6'
+  - 2.7
+  - 3.6
+  - 3.7
   - pypy
 
-cache:
-    directories:
-        - $HOME/.cache/pip
+cache: pip
 
 env:
   - DJANGO_VERSION=2.0.x
+  - DJANGO_VERSION=2.1.x
   - DJANGO_VERSION=1.11.x
-  - DJANGO_VERSION=1.8.x
-
 
 matrix:
   exclude:
-    - python: '3.6'
-      env: DJANGO_VERSION=1.8.x
     - python: '2.7'
-      env: DJANGO_VERSION=2.0.x
-    - python: '3.4'
       env: DJANGO_VERSION=2.0.x
     - python: 'pypy'
       env: DJANGO_VERSION=2.0.x
+    - python: '2.7'
+      env: DJANGO_VERSION=2.1.x
+    - python: 'pypy'
+      env: DJANGO_VERSION=2.1.x
 
 install:
   - pip install tox

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(*parts):
 
 
 install_requires = [
-    'Django>=1.11,<=2.1',
+    'Django>=1.11,<=2.2',
     'celery>=3.0,<5.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(*parts):
 
 
 install_requires = [
-    'Django>=1.6,<2.1',
+    'Django>=1.11,<=2.1',
     'celery>=3.0,<5.0',
 ]
 
@@ -66,8 +66,8 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 import sys
 from setuptools import setup
 
-version = '0.2.0'
+version = '0.3.0'
 
 
 if sys.argv[-1] == 'publish':

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: Implementation :: PyPy',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -48,9 +48,3 @@ deps =
 basepython = python3.7
 deps =
     {[testenv]deps21}
-
-[testenv:pypy-1.11.x]
-basepython = pypy
-deps =
-    {[testenv]deps111}
-

--- a/tox.ini
+++ b/tox.ini
@@ -10,41 +10,12 @@ commands =
     pip install -e .[tests]
     make test
 
-deps18 =
-    https://github.com/django/django/archive/stable/1.8.x.tar.gz#egg=django
-deps111 =
-    https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
-deps20 = 
-    https://github.com/django/django/archive/stable/2.0.x.tar.gz#egg=django
-
-
-[testenv:2.7-1.8.x]
-basepython = python2.7
-deps =
-    {[testenv]deps18}
-
-[testenv:3.4-1.8.x]
-basepython = python3.4
-deps =
-    {[testenv]deps18}
-
-[testenv:3.5-1.8.x]
-basepython = python3.5
-deps =
-    {[testenv]deps18}
+deps111 = Django>=1.11,<1.12
+deps20 = Django>=2.0,<2.1
+deps21 = Django>=2.1,<2.2
 
 [testenv:2.7-1.11.x]
 basepython = python2.7
-deps =
-    {[testenv]deps111}
-
-[testenv:3.4-1.11.x]
-basepython = python3.4
-deps =
-    {[testenv]deps111}
-
-[testenv:3.5-1.11.x]
-basepython = python3.5
 deps =
     {[testenv]deps111}
 
@@ -53,20 +24,30 @@ basepython = python3.6
 deps =
     {[testenv]deps111}
 
-[testenv:3.5-2.0.x]
-basepython = python3.5
+[testenv:3.7-1.11.x]
+basepython = python3.7
 deps =
-    {[testenv]deps20}
+    {[testenv]deps111}
 
 [testenv:3.6-2.0.x]
 basepython = python3.6
 deps =
     {[testenv]deps20}
 
-[testenv:pypy-1.8.x]
-basepython = pypy
+[testenv:3.7-2.0.x]
+basepython = python3.7
 deps =
-    {[testenv]deps18}
+    {[testenv]deps20}
+
+[testenv:3.6-2.1.x]
+basepython = python3.6
+deps =
+    {[testenv]deps21}
+
+[testenv:3.7-2.1.x]
+basepython = python3.7
+deps =
+    {[testenv]deps21}
 
 [testenv:pypy-1.11.x]
 basepython = pypy

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ commands =
 deps111 = Django>=1.11,<1.12
 deps20 = Django>=2.0,<2.1
 deps21 = Django>=2.1,<2.2
+deps22 = Django>=2.2,<2.3
 
 [testenv:2.7-1.11.x]
 basepython = python2.7
@@ -48,3 +49,14 @@ deps =
 basepython = python3.7
 deps =
     {[testenv]deps21}
+    
+
+[testenv:3.6-2.2.x]
+basepython = python3.6
+deps =
+    {[testenv]deps22}
+
+[testenv:3.7-2.2.x]
+basepython = python3.7
+deps =
+    {[testenv]deps22}


### PR DESCRIPTION
This also adds Django 2.1 support.

Fixes #14 
Closes https://github.com/mozilla/django-post-request-task/pull/13