### PR TITLE
Add support for django 3.0 and 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,19 @@ dist: xenial
 language: python
 
 python:
-  - 2.7
   - 3.6
   - 3.7
+  - 3.8
 
 cache: pip
 
 env:
+  - DJANGO_VERSION=1.11.x
   - DJANGO_VERSION=2.0.x
   - DJANGO_VERSION=2.1.x
   - DJANGO_VERSION=2.2.x
-  - DJANGO_VERSION=1.11.x
-
-matrix:
-  exclude:
-    - python: 2.7
-      env: DJANGO_VERSION=2.0.x
-    - python: 2.7
-      env: DJANGO_VERSION=2.1.x
-    - python: 2.7
-      env: DJANGO_VERSION=2.2.x
+  - DJANGO_VERSION=3.0.x
+  - DJANGO_VERSION=3.1.x
 
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -14,11 +14,8 @@ deps111 = Django>=1.11,<1.12
 deps20 = Django>=2.0,<2.1
 deps21 = Django>=2.1,<2.2
 deps22 = Django>=2.2,<2.3
-
-[testenv:2.7-1.11.x]
-basepython = python2.7
-deps =
-    {[testenv]deps111}
+deps30 = Django>=3.0,<3.1
+deps31 = Django>=3.1,<3.2
 
 [testenv:3.6-1.11.x]
 basepython = python3.6
@@ -27,6 +24,11 @@ deps =
 
 [testenv:3.7-1.11.x]
 basepython = python3.7
+deps =
+    {[testenv]deps111}
+
+[testenv:3.8-1.11.x]
+basepython = python3.8
 deps =
     {[testenv]deps111}
 
@@ -40,6 +42,11 @@ basepython = python3.7
 deps =
     {[testenv]deps20}
 
+[testenv:3.8-2.0.x]
+basepython = python3.8
+deps =
+    {[testenv]deps20}
+
 [testenv:3.6-2.1.x]
 basepython = python3.6
 deps =
@@ -49,7 +56,11 @@ deps =
 basepython = python3.7
 deps =
     {[testenv]deps21}
-    
+
+[testenv:3.8-2.1.x]
+basepython = python3.8
+deps =
+    {[testenv]deps21}
 
 [testenv:3.6-2.2.x]
 basepython = python3.6
@@ -60,3 +71,38 @@ deps =
 basepython = python3.7
 deps =
     {[testenv]deps22}
+
+[testenv:3.8-2.2.x]
+basepython = python3.8
+deps =
+    {[testenv]deps22}
+
+[testenv:3.6-3.0.x]
+basepython = python3.6
+deps =
+    {[testenv]deps30}
+
+[testenv:3.7-3.0.x]
+basepython = python3.7
+deps =
+    {[testenv]deps30}
+
+[testenv:3.8-3.0.x]
+basepython = python3.8
+deps =
+    {[testenv]deps30}
+
+[testenv:3.6-3.1.x]
+basepython = python3.6
+deps =
+    {[testenv]deps31}
+
+[testenv:3.7-3.1.x]
+basepython = python3.7
+deps =
+    {[testenv]deps31}
+
+[testenv:3.8-3.1.x]
+basepython = python3.8
+deps =
+    {[testenv]deps31}


### PR DESCRIPTION
Add Django 3.x series to tox matrix.

Remove Python 2.7, which has gone EOL.
Add Python 3.8.