### PR TITLE
Update Celery version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,13 +32,13 @@ Usage
         pass
 
 
-Or, if you are using the task decorator directly:
+Or, if you are using the decorator directly:
 
 .. code-block:: python
 
-    from post_request_task.task import task
+    from post_request_task.task import shared_task
 
-    @task
+    @shared_task
     def my_task():
         pass
 

--- a/post_request_task/task.py
+++ b/post_request_task/task.py
@@ -5,7 +5,7 @@ from functools import partial
 from django.core.signals import (got_request_exception, request_finished,
                                  request_started)
 
-from celery import task as base_task
+from celery import shared_task as base_task
 from celery import Task
 
 

--- a/post_request_task/task.py
+++ b/post_request_task/task.py
@@ -82,11 +82,12 @@ def _append_task(t):
 class PostRequestTask(Task):
     """A task whose execution is delayed until after the request finishes.
 
-    This simply wraps celery's `@task` decorator and stores the task calls
-    until after the request is finished, then fires them off.
+    This simply wraps celery's `@app.task` and `@shared_task` decorators and
+    stores the task calls until after the request is finished, then fires them
+    off.
 
     If no request was started in this thread, behaves exactly like the original
-    @task decorator, sending tasks to celery directly.
+    decorator, sending tasks to celery directly.
     """
     abstract = True
 
@@ -103,8 +104,8 @@ class PostRequestTask(Task):
         return result
 
 
-# Replacement `@task` decorator.
-task = partial(base_task, base=PostRequestTask)
+# Replacement `@shared_task` decorator.
+shared_task = partial(base_task, base=PostRequestTask)
 
 
 # Hook the signal handlers up.

--- a/post_request_task/tests.py
+++ b/post_request_task/tests.py
@@ -4,8 +4,9 @@ from django.test import TestCase
 
 from celery import current_app
 from unittest.mock import Mock, patch
-from post_request_task.task import (task, _get_task_queue, _discard_tasks,
-                                    _start_queuing_tasks, _stop_queuing_tasks,
+from post_request_task.task import (shared_task, _get_task_queue,
+                                    _discard_tasks, _start_queuing_tasks,
+                                    _stop_queuing_tasks,
                                     is_task_queuing_enabled_for_this_thread)
 
 
@@ -15,12 +16,12 @@ current_app.conf.CELERY_ALWAYS_EAGER = True
 task_mock = Mock()
 
 
-@task
+@shared_task
 def test_task():
     task_mock()
 
 
-@task
+@shared_task
 def test_task_with_args_and_kwargs(foo, bar=None):
     task_mock(foo, bar=bar)
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def read(*parts):
 
 install_requires = [
     'Django>=2.2',
-    'celery>=3.0,<5.0',
+    'celery>=4.0',
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,11 @@ deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
+    celery40: celery>=4.0,<5.0
+    celery50: celery>=5.0,<6.0
 commands =
     pip install -e .
     make test
 
 [tox]
-envlist = {py36,py37,py38,py39}-django{22,30,31}
+envlist = {py36,py37,py38,py39}-django{22,30,31}-celery{40,50}


### PR DESCRIPTION
Use Celery shared_task decorator instead of the task. Update the minimum version of the celery to 4.0.
The last Celery 3 release was in 2018 that's why it makes sense to upgrade to 4.

Resolves: #24